### PR TITLE
Add tests for unixtime conversion functions 

### DIFF
--- a/libs/resea/datetime.c
+++ b/libs/resea/datetime.c
@@ -3,8 +3,8 @@
 #include <resea/datetime.h>
 
 static bool is_leap_year(uint32_t year) {
-    return (year) % 4 == 0
-           && ((year) % 100 != 0 || (year) % 400 == 0);
+    return (((year % 4 == 0) && (year % 100 != 0)) ||
+        (year % 400 == 0));
 }
 
 uint64_t datetime_to_timestamp(struct datetime *datetime) {
@@ -52,12 +52,12 @@ void timestamp_to_datetime(uint64_t epoch, struct datetime *datetime) {
     epoch /= 24;
     datetime->day_of_week = ((epoch + 4) % 7) + 1;
 
-    year = 0;
+    year = 1970;
     day = 0;
     while((day += (is_leap_year(year) ? 366 : 365)) <= epoch) {
         year++;
     }
-    datetime->year = year + 1970;
+    datetime->year = year;
 
     day -= is_leap_year(year) ? 366 : 365;
     epoch -= day;

--- a/servers/apps/test/build.mk
+++ b/servers/apps/test/build.mk
@@ -1,3 +1,3 @@
 name := test
 description := The integrated tests for kernel and standard library
-objs-y := main.o ipc_test.o libcommon_test.o libresea_test.o unittest_test.o malloc_test.o
+objs-y := main.o ipc_test.o libcommon_test.o libresea_test.o unittest_test.o malloc_test.o datetime_test.o

--- a/servers/apps/test/datetime_test.c
+++ b/servers/apps/test/datetime_test.c
@@ -1,0 +1,41 @@
+#include <resea/malloc.h>
+#include <resea/printf.h>
+#include <resea/datetime.h>
+#include <string.h>
+#include "test.h"
+
+#define TEST_START_TIME 1577836800 // January 1 2020 12:00:00 AM
+#define TEST_END_TIME   1577923200 // January 2 2020 12:00:00 AM
+
+void datetime_test(void) {
+    uint64_t timestamp = TEST_START_TIME;
+    struct datetime datetime;
+    timestamp_to_datetime(timestamp, &datetime);
+
+    while (timestamp <= TEST_END_TIME) {
+        timestamp_to_datetime(timestamp, &datetime);
+        TEST_ASSERT(datetime.second >= 0 && datetime.second < 60);
+        TEST_ASSERT(datetime.minute >= 0 && datetime.minute < 60);
+        TEST_ASSERT(datetime.hour >= 0 && datetime.hour < 24);
+        TEST_ASSERT(datetime.month == 1);
+        TEST_ASSERT(datetime.year == 2020);
+        ++timestamp;
+    }
+
+    // Test for start of epoch time
+    timestamp = 0;
+    timestamp_to_datetime(timestamp, &datetime);
+    TEST_ASSERT(datetime.day == 1);
+    TEST_ASSERT(datetime.month == 1);
+    TEST_ASSERT(datetime.year == 1970);
+
+    // Test datetime struct one day after epoch
+    datetime.second = 0;
+    datetime.minute = 0;
+    datetime.hour = 0;
+    datetime.day = 2;
+    datetime.month = 1;
+    datetime.year = 1970;
+    timestamp = datetime_to_timestamp(&datetime);
+    TEST_ASSERT(timestamp == 86400);
+}

--- a/servers/apps/test/datetime_test.c
+++ b/servers/apps/test/datetime_test.c
@@ -4,38 +4,57 @@
 #include <string.h>
 #include "test.h"
 
-#define TEST_START_TIME 1577836800 // January 1 2020 12:00:00 AM
-#define TEST_END_TIME   1577923200 // January 2 2020 12:00:00 AM
-
 void datetime_test(void) {
-    uint64_t timestamp = TEST_START_TIME;
+    uint64_t timestamp, timestamp_new;
     struct datetime datetime;
+
+    // Test for random case
+    // Friday, November 20, 2020 10:00:00 AM
+    timestamp = 1605866400;
     timestamp_to_datetime(timestamp, &datetime);
 
-    while (timestamp <= TEST_END_TIME) {
-        timestamp_to_datetime(timestamp, &datetime);
-        TEST_ASSERT(datetime.second >= 0 && datetime.second < 60);
-        TEST_ASSERT(datetime.minute >= 0 && datetime.minute < 60);
-        TEST_ASSERT(datetime.hour >= 0 && datetime.hour < 24);
-        TEST_ASSERT(datetime.month == 1);
-        TEST_ASSERT(datetime.year == 2020);
-        ++timestamp;
-    }
+    TEST_ASSERT(datetime.second == 0);
+    TEST_ASSERT(datetime.minute == 0);
+    TEST_ASSERT(datetime.hour == 10);
+    TEST_ASSERT(datetime.day == 20);
+    TEST_ASSERT(datetime.day_of_week == 6);
+    TEST_ASSERT(datetime.month == 11);
+    TEST_ASSERT(datetime.year == 2020);
+
+    timestamp_new = datetime_to_timestamp(&datetime);
+    TEST_ASSERT(timestamp_new == timestamp);
+
+    // Test for leap year case
+    // Saturday, February 29, 2020 12:34:56 PM
+    timestamp = 1582979696;
+    timestamp_to_datetime(timestamp, &datetime);
+
+    TEST_ASSERT(datetime.second == 56);
+    TEST_ASSERT(datetime.minute == 34);
+    TEST_ASSERT(datetime.hour == 12);
+    TEST_ASSERT(datetime.day == 29);
+    TEST_ASSERT(datetime.day_of_week == 7);
+    TEST_ASSERT(datetime.month == 2);
+    TEST_ASSERT(datetime.year == 2020);
+
+    timestamp_new = datetime_to_timestamp(&datetime);
+    TEST_ASSERT(timestamp_new == timestamp);
 
     // Test for start of epoch time
     timestamp = 0;
     timestamp_to_datetime(timestamp, &datetime);
+
+    TEST_ASSERT(datetime.second == 0);
+    TEST_ASSERT(datetime.minute == 0);
+    TEST_ASSERT(datetime.hour == 0);
     TEST_ASSERT(datetime.day == 1);
+    TEST_ASSERT(datetime.day_of_week == 5);
     TEST_ASSERT(datetime.month == 1);
     TEST_ASSERT(datetime.year == 1970);
 
-    // Test datetime struct one day after epoch
-    datetime.second = 0;
-    datetime.minute = 0;
-    datetime.hour = 0;
-    datetime.day = 2;
-    datetime.month = 1;
-    datetime.year = 1970;
-    timestamp = datetime_to_timestamp(&datetime);
-    TEST_ASSERT(timestamp == 86400);
+    timestamp_new = datetime_to_timestamp(&datetime);
+    TEST_ASSERT(timestamp_new == timestamp);
+
+    // Testing for end of epoch time is going to be time consuming.
+    // Since we are using 64-bit timestamps.
 }

--- a/servers/apps/test/main.c
+++ b/servers/apps/test/main.c
@@ -16,6 +16,7 @@ void main(void) {
     libcommon_test();
     libresea_test();
     malloc_test();
+    datetime_test();
 
     if (failed) {
         WARN("Failed %d tests", failed);

--- a/servers/apps/test/test.h
+++ b/servers/apps/test/test.h
@@ -16,5 +16,5 @@ void ipc_test(void);
 void libcommon_test(void);
 void libresea_test(void);
 void malloc_test(void);
+void datetime_test(void);
 #endif
-


### PR DESCRIPTION
This PR fixes a minor issue in the conversion function and adds tests for the same functions.

Please let me know if you want any particular test cases to be included.